### PR TITLE
Add tequilapi error property

### DIFF
--- a/lib/tequilapi-error.js.flow
+++ b/lib/tequilapi-error.js.flow
@@ -18,6 +18,7 @@ declare export default class TequilapiError mixins Error {
   name: string;
   _originalError: AxiosError;
   constructor(originalError: Error, path: string): this;
+  isTequilapiError: boolean;
   code: string | void;
   isTimeoutError: boolean;
   isRequestClosedError: boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mysterium-tequilapi",
-  "version": "0.7.5",
+  "version": "0.7.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mysterium-tequilapi",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Api library to control mysterium client and node",
   "repository": "github:mysteriumnetwork/mysterium-tequilapi",
   "main": "lib/index.js",

--- a/src/tequilapi-error.ts
+++ b/src/tequilapi-error.ts
@@ -32,6 +32,10 @@ export default class TequilapiError extends Error {
     this._originalError = originalError
   }
 
+  get isTequilapiError (): boolean {
+    return true
+  }
+
   get code (): string | undefined {
     return this._originalError.code
   }

--- a/test/unit/tequilapi-error.spec.ts
+++ b/test/unit/tequilapi-error.spec.ts
@@ -57,6 +57,12 @@ describe('TequilapiError', () => {
     })
   })
 
+  describe('.isTequilapiError', () => {
+    it('returns true', () => {
+      expect(simpleTequilapiError.isTequilapiError).toBe(true)
+    })
+  })
+
   describe('.code', () => {
     it('returns undefined for simple error', () => {
       expect(simpleTequilapiError.code).toBeUndefined()


### PR DESCRIPTION
Currently, in desktop we're using `if (err.name === TequilapiError.name)` to assert if `err` is tequilapi error. This works in development environment, but does not work in production - 'TequilapiError.name` equals `Error` in production to due to complex nature of `Error` object.

Now we'll be able to use `if (err.isTequilapiError)`.